### PR TITLE
Fixed incorrect row deletion in reversed list

### DIFF
--- a/score_counter WatchKit Extension/Models/Events.swift
+++ b/score_counter WatchKit Extension/Models/Events.swift
@@ -36,6 +36,10 @@ class EventsModel: ObservableObject, Identifiable, Codable {
         events.remove(atOffsets: offset)
     }
     
+    func deleteAtIndex(index: Int){
+        events.remove(at: index)
+    }
+    
     required init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         events = try values.decode([Event].self, forKey: .events)

--- a/score_counter WatchKit Extension/Views/List/EventList.swift
+++ b/score_counter WatchKit Extension/Views/List/EventList.swift
@@ -18,7 +18,12 @@ struct EventList: View {
                     Spacer()
                 }
             }.onDelete(perform: { indexSet in
-                eventsModel.deleteAtOffsets(offset: indexSet)
+                indexSet.forEach { i in
+                    //Since the list is reversed,
+                    //the index is length(arr) - i - 1
+                    let j = (eventsModel.events.count - 1) - i
+                    eventsModel.deleteAtIndex(index: j)
+                }
             })
         }
     }


### PR DESCRIPTION
When deleting a row in the list, the incorrect row was being deleted. This was due to the list being displayed as reversed and this not being taken into account when making the deletion.